### PR TITLE
Handle empty messages

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -21,10 +21,16 @@ export async function run(): Promise<void> {
     const decodedReadme = fs.readFileSync(fileName, 'utf-8')
 
     const numberOfMessages = Number(core.getInput('NUMBER_OF_MESSAGES'))
-    const messages = supporters.data
-      .slice(0, numberOfMessages)
-      .map((supporter: CoffeeSupporter) => generateMessageLine(supporter))
-      .join('\n')
+    const messages = Array.isArray(supporters?.data)
+      ? supporters.data
+        .slice(0, numberOfMessages)
+        .map((supporter: CoffeeSupporter) => generateMessageLine(supporter))
+        .join('\n')
+      : ''
+    if (!messages) {
+        core.info("No supporters yet!")
+        return;
+    }
     const updatedReadme = saveBMAC2File(decodedReadme, messages)
 
     fs.writeFileSync(fileName, updatedReadme);


### PR DESCRIPTION
Solves #110

Currently, `run()` fails when no messages are returned by `coffee.Supporters()` with:

```
Error: Cannot read properties of undefined (reading 'slice')
```

This patch prevents accessing the undefined `supporters.data`  with a guard placed with a ternary operator.
Furthermore, it adds an early exit if no messages were returned, shortcutting the rest of the logic.